### PR TITLE
use <code> for GID when listing downloads

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -176,8 +176,7 @@ class Bot:
 
                 individual.append('<b>Name:</b> ' + task_name)
 
-                individual.append('<b>GID:</b> ' + download['gid'])
-
+                individual.append('<b>GID:</b> <code>' + download['gid'] + '</code>')
                 completed_length = int(download['completedLength'])
 
                 if status in ['active', 'paused']:
@@ -212,7 +211,7 @@ class Bot:
                 # Only show name and gid if the download is not initialized.
                 response_list.append('\n'.join([
                     '<b>Name:</b> Unknown',
-                    '<b>GID:</b> ' + download['gid']
+                    '<b>GID:</b><code> ' + download['gid'] + '</code>'
                 ]))
 
             response_text = '\n\n'.join(response_list)


### PR DESCRIPTION
This has been very helpful for me on android telegram clients, if I have to pause/resume/remove any downloads I can just long press to hold and get the information in <code> </code> to my clipboard.